### PR TITLE
Add files via upload

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo This file can not be run under Sudo.
+
+DESTINATION_DIR=${XDG_DATA_HOME:-~/.local/share}/applications
+IN_FILE=io.YGO_OMEGA.Desktop.in
+OUT_NAME=io.YGO_OMEGA.desktop
+
+cd $(dirname $0) &&
+sed "s|{INSTALL_PATH}|$PWD|" $IN_FILE > $DESTINATION_DIR/$OUT_NAME &&
+chmod +x $DESTINATION_DIR/$OUT_NAME

--- a/io.YGO_OMEGA.Desktop.in
+++ b/io.YGO_OMEGA.Desktop.in
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Encoding=UTF-8
+Type=Application
+Name=YGO Omega Launcher 
+Path={INSTALL_PATH}
+Exec={INSTALL_PATH}/./YGO\ Omega.x86_64
+Icon={INSTALL_PATH}/YGO Omega_Data/Resources/UnityPlayer.png
+Terminal=false
+Categories=Game;CardGame;3DSimulator


### PR DESCRIPTION
These files work to make a App Menu Image to Linux Debian/Gnome Builds. If we could add them to the tar.gz download package. The files have to be set in the initial install folder in order to operate properly.